### PR TITLE
Adding scenario description to Allure reports

### DIFF
--- a/src/main/java/com/techconative/restel/core/model/RestelTestScenario.java
+++ b/src/main/java/com/techconative/restel/core/model/RestelTestScenario.java
@@ -16,6 +16,7 @@ import lombok.Data;
 @Data
 public class RestelTestScenario {
   private String scenarioName;
+  private String scenarioDescription;
   private List<String> testApis;
   private String testSuiteName;
   private List<RestelTestScenario> dependsOn;

--- a/src/main/java/com/techconative/restel/core/parser/config/ParserConfig.java
+++ b/src/main/java/com/techconative/restel/core/parser/config/ParserConfig.java
@@ -80,6 +80,7 @@ public class ParserConfig {
     // Test_Scenarios sheet - start
     fieldMap = new HashMap<>();
     fieldMap.put(Constants.SCENARIO_UNIQUE_NAME, Functions.STRING_FUNCTION);
+    fieldMap.put(Constants.SCENARIO_DESC, Functions.STRING_FUNCTION);
     fieldMap.put(Constants.TEST_SUITE, Functions.STRING_FUNCTION);
     fieldMap.put(Constants.TEST_APIS, Functions.TO_STRING_LIST);
     fieldMap.put(Constants.DEPENDS_ON, Functions.STRING_FUNCTION);

--- a/src/main/java/com/techconative/restel/core/parser/dto/TestScenarios.java
+++ b/src/main/java/com/techconative/restel/core/parser/dto/TestScenarios.java
@@ -9,6 +9,8 @@ public class TestScenarios {
 
   private String scenarioUniqueName;
 
+  private String scenarioDescription;
+
   private String testSuite;
 
   private List<String> testApis;

--- a/src/main/java/com/techconative/restel/testng/TestCase.java
+++ b/src/main/java/com/techconative/restel/testng/TestCase.java
@@ -29,6 +29,7 @@ public class TestCase {
   @Parameters({"name"})
   @Test
   public void executeTest(String name) {
+    Allure.description(testExecutor.getExecutionGroup().getScenarioDescription());
     Allure.step(
         "Start Executing the "
             .concat(scenarioName)

--- a/src/main/java/com/techconative/restel/utils/Constants.java
+++ b/src/main/java/com/techconative/restel/utils/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
 
   // Test suite execution
   public static final String SCENARIO_UNIQUE_NAME = "scenario_unique_name";
+  public static final String SCENARIO_DESC = "scenario_description";
   public static final String TEST_SUITE = "test_suite";
   public static final String TEST_APIS = "test_apis";
   public static final String SCENARIO_ENABLED = "scenario_enabled";

--- a/src/main/java/com/techconative/restel/utils/RestelUtils.java
+++ b/src/main/java/com/techconative/restel/utils/RestelUtils.java
@@ -122,6 +122,7 @@ public class RestelUtils {
         scenarios.getScenarioEnabled() == null ? Boolean.TRUE : scenarios.getScenarioEnabled();
     RestelTestScenario restelExecutionGroup = new RestelTestScenario();
     restelExecutionGroup.setScenarioName(scenarios.getScenarioUniqueName());
+    restelExecutionGroup.setScenarioDescription(scenarios.getScenarioDescription());
     restelExecutionGroup.setTestApis(scenarios.getTestApis());
     restelExecutionGroup.setScenarioEnabled(enable);
     restelExecutionGroup.setTestSuiteName(scenarios.getTestSuite());

--- a/src/test/java/restel/core/model/RestelExecutionGroupTest.java
+++ b/src/test/java/restel/core/model/RestelExecutionGroupTest.java
@@ -12,6 +12,7 @@ public class RestelExecutionGroupTest {
     RestelTestScenario exec = new RestelTestScenario();
     exec.setDependsOn(null);
     exec.setScenarioName("name");
+    exec.setScenarioDescription("a sample scenario description");
     exec.setExecutionParams(Map.of("k", "v"));
     exec.setTestApis(List.of("def"));
     exec.setTestSuiteName("suite");
@@ -19,6 +20,7 @@ public class RestelExecutionGroupTest {
     Assert.assertNull(exec.getDependsOn());
     Assert.assertEquals(Map.of("k", "v"), exec.getExecutionParams());
     Assert.assertEquals("name", exec.getScenarioName());
+    Assert.assertEquals("a sample scenario description", exec.getScenarioDescription());
     Assert.assertEquals(List.of("def"), exec.getTestApis());
     Assert.assertEquals("suite", exec.getTestSuiteName());
 

--- a/src/test/java/restel/core/parser/dto/TestSuiteExecutionTest.java
+++ b/src/test/java/restel/core/parser/dto/TestSuiteExecutionTest.java
@@ -31,6 +31,12 @@ public class TestSuiteExecutionTest {
     suiteExecution.setScenarioUniqueName("name");
     Assert.assertEquals("name", suiteExecution.getScenarioUniqueName());
 
+    suiteExecution.setScenarioDescription(
+        "A short, crisp description. Might include special characters ;'{//,");
+    Assert.assertEquals(
+        "A short, crisp description. Might include special characters ;'{//,",
+        suiteExecution.getScenarioDescription());
+
     Assert.assertNotEquals(new TestScenarios(), suiteExecution);
     Assert.assertNotEquals(suiteExecution.hashCode(), new TestScenarios().hashCode());
     Assert.assertNotNull(suiteExecution.toString());


### PR DESCRIPTION
Issue #9 
A new field `scenario_description` can be added in `Test_Scenarios` sheet.
This scenario description mentioned in Excel is then added to Allure report.